### PR TITLE
Feat/component manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,13 @@ set(SOURCES
 		${CMAKE_SOURCE_DIR}/src/GameEngine/AGameState.h
 		${CMAKE_SOURCE_DIR}/src/GameEngine/AWorld.cc
 		${CMAKE_SOURCE_DIR}/src/GameEngine/AWorld.h
+		${CMAKE_SOURCE_DIR}/src/GameEngine/ComponentsManager.cc
+		${CMAKE_SOURCE_DIR}/src/GameEngine/ComponentsManager.h
 		${CMAKE_SOURCE_DIR}/src/GameEngine/GameEngine.cc
 		${CMAKE_SOURCE_DIR}/src/GameEngine/GameEngine.h
 		${CMAKE_SOURCE_DIR}/src/GameEngine/ResourcesManager.cc
 		${CMAKE_SOURCE_DIR}/src/GameEngine/ResourcesManager.h
+		${CMAKE_SOURCE_DIR}/src/GameEngine/Settings.h
 
 		# GAME
 		${CMAKE_SOURCE_DIR}/src/Components.h

--- a/src/Components.h
+++ b/src/Components.h
@@ -4,29 +4,6 @@
 #include <bitset>
 #include <SFML/Graphics.hpp>
 
-using Bitset = std::bitset<6>;
-using Entity = Bitset;
-
-namespace component {
-	// BASE
-	Bitset const none = 0;
-	Bitset const position = 1 << 0;
-	Bitset const velocity = 1 << 1;
-	Bitset const sprite = 1 << 2;
-	Bitset const text = 1 << 3;
-	Bitset const input = 1 << 4;
-	Bitset const playerTag = 1 << 5;
-
-	// COMPOSITION
-	Bitset const button = position | text | input;
-	Bitset const drawable = position | sprite ;
-	Bitset const player = position | velocity | sprite | playerTag;
-};
-
-namespace settings {
-	uint32_t const ENTITY_COUNT = 100;
-};
-
 struct Position {
 	float x;
 	float y;

--- a/src/GameEngine/AGameState.h
+++ b/src/GameEngine/AGameState.h
@@ -1,8 +1,6 @@
 #ifndef AGAMESTATE_H_
 #define AGAMESTATE_H_
 
-#include "AWorld.h"
-
 namespace ge {
 	class GameEngine;
 

--- a/src/GameEngine/AWorld.cc
+++ b/src/GameEngine/AWorld.cc
@@ -1,20 +1,20 @@
 #include "AWorld.h"
 
 uint32_t ge::AWorld::GetEmptyIndex_() const {
-	auto it = std::find(std::begin(entities_), std::end(entities_), component::none);
-	return it != std::end(entities_) ? static_cast<uint32_t >(it - std::begin(entities_)) : settings::ENTITY_COUNT;
+	auto it = std::find(std::begin(entities_), std::end(entities_), ge::Components::None);
+	return it != std::end(entities_) ? static_cast<uint32_t >(it - std::begin(entities_)) : ge::Settings::EntitiesCount;
 }
 
 void ge::AWorld::Reset() {
 	for (auto & entity : entities_) {
-		entity = component::none;
+		entity = ge::Components::None;
 	}
 }
 
 void ge::AWorld::RemoveEntity(uint32_t const id) {
-	entities_[id] = component::none;
+	entities_[id] = ge::Components::None;
 }
 
-Entity & ge::AWorld::Entities(uint32_t id) {
+ge::Entity & ge::AWorld::Entities(uint32_t id) {
 	return entities_[id];
 }

--- a/src/GameEngine/AWorld.h
+++ b/src/GameEngine/AWorld.h
@@ -4,7 +4,8 @@
 #include <bitset>
 #include <array>
 #include <SFML/Graphics.hpp>
-#include "Components.h"
+
+#include "Settings.h"
 
 namespace ge {
 	class AWorld {
@@ -23,7 +24,7 @@ namespace ge {
 
 	protected:
 		virtual uint32_t GetEmptyIndex_() const;
-		std::array<Entity, settings::ENTITY_COUNT> entities_;
+		std::array<Entity, Settings::EntitiesCount> entities_;
 	};
 }
 

--- a/src/GameEngine/ComponentsManager.cc
+++ b/src/GameEngine/ComponentsManager.cc
@@ -2,7 +2,15 @@
 
 uint32_t ge::ComponentsManager::count_ = 0;
 
-bool ge::ComponentsManager::AddComponents(std::string const & name) {
+bool ge::ComponentsManager::AddComponents(std::vector<std::string> const & names) {
+	bool ret = true;
+	for (auto & name : names) {
+		ret = ret && AddComponent(name);
+	}
+	return ret;
+}
+
+bool ge::ComponentsManager::AddComponent(std::string const & name) {
 	if (count_ < ge::Settings::ComponentsCount) {
 		if (!components_.count(name)) {
 			components_.insert(std::pair<std::string, Component>(name, Component(static_cast<unsigned long long int>(1 << count_))));

--- a/src/GameEngine/ComponentsManager.cc
+++ b/src/GameEngine/ComponentsManager.cc
@@ -1,0 +1,55 @@
+#include "ComponentsManager.h"
+
+uint32_t ge::ComponentsManager::count_ = 0;
+
+bool ge::ComponentsManager::AddComponents(std::string const & name) {
+	if (count_ < ge::Settings::ComponentsCount) {
+		if (!components_.count(name)) {
+			components_.insert(std::pair<std::string, Component>(name, Component(static_cast<unsigned long long int>(1 << count_))));
+			++count_;
+			return true;
+		}
+		ErrorAddExistingComponent_(name);
+		return false;
+	}
+	ErrorToManyComponents_();
+	return false;
+}
+
+bool ge::ComponentsManager::AddComposedComponents(std::string const & name, std::vector<std::string> const & composition) {
+	if (!components_.count(name)) {
+		Component b(0);
+		for (auto & c : composition) {
+			if (components_.count(c)) {
+				b |= components_[c];
+			} else {
+				ErrorUnknownComponent_(c);
+				return false;
+			}
+		}
+		components_.insert(std::pair<std::string, Component>(name, b));
+		return true;
+	}
+	ErrorAddExistingComponent_(name);
+	return false;
+}
+
+ge::Component const & ge::ComponentsManager::operator[](std::string const & name) const {
+	if (components_.count(name)) {
+		return components_.at(name);
+	}
+	ErrorUnknownComponent_(name);
+	return ge::Components::None;
+}
+
+void ge::ComponentsManager::ErrorAddExistingComponent_(std::string const &name) const {
+	std::cerr << "ComponentManager : Component " << name << " already exist" <<std::endl;
+}
+
+void ge::ComponentsManager::ErrorUnknownComponent_(std::string const &name) const {
+	std::cerr << "ComponentManager : Component " << name << " doesn't exist" <<std::endl;
+}
+
+void ge::ComponentsManager::ErrorToManyComponents_() const {
+	std::cerr << "ComponentManager : To many basic components" <<std::endl;
+}

--- a/src/GameEngine/ComponentsManager.h
+++ b/src/GameEngine/ComponentsManager.h
@@ -1,0 +1,38 @@
+#ifndef COMPONENTSMANAGER_H
+#define COMPONENTSMANAGER_H
+
+#include <unordered_map>
+#include <vector>
+#include <iostream>
+
+#include "Settings.h"
+
+namespace ge {
+	class ComponentsManager {
+	public:
+		ComponentsManager() = default;
+		ComponentsManager(ComponentsManager const & other) = delete;
+		ComponentsManager(ComponentsManager && other) = delete;
+		~ComponentsManager() = default;
+
+		ComponentsManager & operator=(ComponentsManager const & other) = delete;
+		ComponentsManager & operator=(ComponentsManager && other) = delete;
+
+		bool AddComponents(std::string const & name);
+		bool AddComposedComponents(std::string const & name, std::vector<std::string> const & composition);
+
+		Component const & operator[](std::string const & name) const;
+
+	private:
+		void ErrorAddExistingComponent_(std::string const & name) const;
+		void ErrorUnknownComponent_(std::string const & name) const;
+		void ErrorToManyComponents_() const;
+
+		static uint32_t count_;
+
+		std::unordered_map<std::string, Component> components_;
+	};
+}
+
+
+#endif /*COMPONENTSMANAGER_H*/

--- a/src/GameEngine/ComponentsManager.h
+++ b/src/GameEngine/ComponentsManager.h
@@ -18,7 +18,8 @@ namespace ge {
 		ComponentsManager & operator=(ComponentsManager const & other) = delete;
 		ComponentsManager & operator=(ComponentsManager && other) = delete;
 
-		bool AddComponents(std::string const & name);
+		bool AddComponent(std::string const & name);
+		bool AddComponents(std::vector<std::string> const & names);
 		bool AddComposedComponents(std::string const & name, std::vector<std::string> const & composition);
 
 		Component const & operator[](std::string const & name) const;

--- a/src/GameEngine/GameEngine.cc
+++ b/src/GameEngine/GameEngine.cc
@@ -119,6 +119,14 @@ ge::ResourcesManager & ge::GameEngine::Rm() {
 	return rm_;
 }
 
+ge::ComponentsManager &ge::GameEngine::Cm() {
+	return cm_;
+}
+
+ge::ComponentsManager const & ge::GameEngine::Cm() const {
+	return cm_;
+}
+
 void ge::GameEngine::Draw(std::shared_ptr<sf::Drawable> const & drawable, int32_t const display_level) {
 	toDraw_.push(PrioritizedDrawable(display_level, drawable));
 }

--- a/src/GameEngine/GameEngine.h
+++ b/src/GameEngine/GameEngine.h
@@ -11,17 +11,12 @@
 #include <functional>
 #include <queue>
 
+#include "Settings.h"
 #include "ResourcesManager.h"
+#include "ComponentsManager.h"
 #include "AGameState.h"
 
-using PrioritizedDrawable = std::pair<int32_t , std::shared_ptr<sf::Drawable>>;
-
 namespace ge {
-	namespace Layer {
-		static constexpr int32_t UI = 0;
-		static constexpr int32_t Background = -1;
-	}
-
 	class GameEngine {
 	public:
 		GameEngine();
@@ -46,6 +41,8 @@ namespace ge {
 		void Quit();
 
 		ResourcesManager & Rm();
+		ComponentsManager & Cm();
+		ComponentsManager const & Cm() const;
 
 	private:
 		void HandleEvents_();
@@ -58,6 +55,7 @@ namespace ge {
 		sf::RenderWindow window_;
 
 		ResourcesManager rm_;
+		ComponentsManager cm_;
 
 		std::priority_queue<PrioritizedDrawable,
 			std::vector<PrioritizedDrawable>,

--- a/src/GameEngine/Settings.h
+++ b/src/GameEngine/Settings.h
@@ -1,0 +1,28 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <bitset>
+#include <memory>
+#include <SFML/Graphics/Drawable.hpp>
+
+namespace ge {
+	namespace Settings {
+		static constexpr uint32_t EntitiesCount = 100;
+		static constexpr uint32_t ComponentsCount = 100;
+	};
+
+	namespace Layer {
+		static constexpr int32_t UI = 0;
+		static constexpr int32_t Background = -1;
+	}
+
+	using Component = std::bitset<Settings::ComponentsCount>;
+	using Entity = Component;
+	using PrioritizedDrawable = std::pair<int32_t , std::shared_ptr<sf::Drawable>>;
+
+	namespace Components {
+		static constexpr Component None = 0;
+	}
+}
+
+#endif /*SETTINGS_H*/

--- a/src/IntroState.cc
+++ b/src/IntroState.cc
@@ -2,8 +2,8 @@
 
 bool IntroState::Init(ge::GameEngine & engine) {
 	engine.Rm().LoadFont("arial", "resources/arial.ttf");
-	world_.CreateButton({ 300, 0 }, { "Start", "arial" }, { START });
-	world_.CreateButton({ 300, 100 }, { "Quit", "arial" }, { QUIT });
+	world_.CreateButton(engine.Cm()["Button"], { 300, 0 }, { "Start", "arial" }, { START });
+	world_.CreateButton(engine.Cm()["Button"], { 300, 100 }, { "Quit", "arial" }, { QUIT });
 	return true;
 }
 
@@ -18,12 +18,12 @@ void IntroState::Resume() {
 }
 
 void IntroState::HandleClick_(ge::GameEngine & engine, sf::Event::MouseButtonEvent const & event) {
-	for (uint32_t id = 0; id < settings::ENTITY_COUNT; ++id) {
-		Entity & entity = world_.Entities(id);
+	for (uint32_t id = 0; id < ge::Settings::EntitiesCount; ++id) {
+		ge::Entity & entity = world_.Entities(id);
 		Text & text = world_.Texts(id);
 		Input & input = world_.Inputs(id);
 		Position & position = world_.Positions(id);
-		if (event.button == sf::Mouse::Button::Left && (entity & component::button) == component::button) {
+		if (event.button == sf::Mouse::Button::Left && (entity & engine.Cm()["Button"]) == engine.Cm()["Button"]) {
 			sf::Text t(text.text, engine.Rm().Font(text.fontName));
 			t.setPosition(position.x, position.y);
 			if (t.getGlobalBounds().contains(static_cast<float>(event.x), static_cast<float>(event.y))) {
@@ -55,11 +55,11 @@ void IntroState::Update(ge::GameEngine const & game) {
 }
 
 void IntroState::Display(ge::GameEngine & engine, const float) {
-	for (uint32_t id = 0; id < settings::ENTITY_COUNT; ++id) {
-		Entity & entity = world_.Entities(id);
+	for (uint32_t id = 0; id < ge::Settings::EntitiesCount; ++id) {
+		ge::Entity & entity = world_.Entities(id);
 		Text & text = world_.Texts(id);
 		Position & position = world_.Positions(id);
-		if ((entity & component::button) == component::button) {
+		if ((entity & engine.Cm()["Button"]) == engine.Cm()["Button"]) {
 			sf::Text t(text.text, engine.Rm().Font(text.fontName));
 			t.setPosition(position.x, position.y);
 			engine.Draw(std::make_shared<sf::Text>(t), ge::Layer::UI);

--- a/src/IntroWorld.cc
+++ b/src/IntroWorld.cc
@@ -1,8 +1,8 @@
 #include "IntroWorld.h"
 
-uint32_t IntroWorld::CreateButton(Position const & position, Text const & text, Input const & input) {
+uint32_t IntroWorld::CreateButton(ge::Component const & component, Position const & position, Text const & text, Input const & input) {
 	uint32_t id = GetEmptyIndex_();
-	entities_[id] = component::button;
+	entities_[id] = component;
 	positions_[id] = position;
 	texts_[id] = text;
 	inputs_[id] = input;

--- a/src/IntroWorld.h
+++ b/src/IntroWorld.h
@@ -2,6 +2,7 @@
 #define WORLD_H_
 
 #include "AWorld.h"
+#include "Components.h"
 
 class IntroWorld : public ge::AWorld {
 public:
@@ -13,16 +14,16 @@ public:
 	IntroWorld & operator=(IntroWorld const & other) = delete;
 	IntroWorld & operator=(IntroWorld && other) = delete;
 
-	uint32_t CreateButton(Position const & position, Text const & text, Input const & input);
+	uint32_t CreateButton(ge::Component const & component, Position const & position, Text const & text, Input const & input);
 
 	Position & Positions(uint32_t id);
 	Text & Texts(uint32_t id);
 	Input & Inputs(uint32_t id);
 
 private:
-	std::array<Position, settings::ENTITY_COUNT> positions_;
-	std::array<Text, settings::ENTITY_COUNT> texts_;
-	std::array<Input, settings::ENTITY_COUNT> inputs_;
+	std::array<Position, ge::Settings::EntitiesCount> positions_;
+	std::array<Text, ge::Settings::EntitiesCount> texts_;
+	std::array<Input, ge::Settings::EntitiesCount> inputs_;
 };
 
 #endif /* WORLD_H_ */

--- a/src/PlayState.cc
+++ b/src/PlayState.cc
@@ -4,8 +4,8 @@
 bool PlayState::Init(ge::GameEngine & engine) {
 	engine.Rm().LoadTexture("nyancat", "resources/nyancat.png");
 	engine.Rm().LoadTexture("red_cross", "resources/red_cross.png");
-	world_.CreatePlayer({ 300, 300 }, { 0, 0 }, { "nyancat", 1 });
-	world_.CreateCross({ 30, 30 }, { "red_cross", 2 });
+	world_.CreatePlayer(engine.Cm()["Player"], { 300, 300 }, { 0, 0 }, { "nyancat", 1 });
+	world_.CreateCross(engine.Cm()["Drawable"], { 30, 30 }, { "red_cross", 2 });
 	return true;
 }
 
@@ -19,11 +19,11 @@ void PlayState::Pause() {
 void PlayState::Resume() {
 }
 
-void PlayState::HandlePlayerMovement_(sf::Event::KeyEvent const & event) {
-	for (uint32_t id = 0; id < settings::ENTITY_COUNT; ++id) {
-		Entity & entity = world_.Entities(id);
+void PlayState::HandlePlayerMovement_(ge::GameEngine const & engine, sf::Event::KeyEvent const & event) {
+	for (uint32_t id = 0; id < ge::Settings::EntitiesCount; ++id) {
+		ge::Entity & entity = world_.Entities(id);
 		Velocity & velocity = world_.Velocities(id);
-		if ((entity & component::player) == component::player) {
+		if ((entity & engine.Cm()["Player"]) == engine.Cm()["Player"]) {
 			switch (event.code) {
 				case sf::Keyboard::Key::Left:
 					velocity.x -= 10;
@@ -53,7 +53,7 @@ void PlayState::HandleQuit_(ge::GameEngine & engine, sf::Event::KeyEvent const &
 void PlayState::HandleEvent(ge::GameEngine & engine, sf::Event const & event) {
 	switch (event.type) {
 		case sf::Event::KeyPressed:
-			HandlePlayerMovement_(event.key);
+			HandlePlayerMovement_(engine, event.key);
 			HandleQuit_(engine, event.key);
 			break;
 		default:
@@ -61,12 +61,12 @@ void PlayState::HandleEvent(ge::GameEngine & engine, sf::Event const & event) {
 	}
 }
 
-void PlayState::Update(ge::GameEngine const & game) {
-	for (uint32_t id = 0; id < settings::ENTITY_COUNT; ++id) {
-		Entity & entity = world_.Entities(id);
+void PlayState::Update(ge::GameEngine const & engine) {
+	for (uint32_t id = 0; id < ge::Settings::EntitiesCount; ++id) {
+		ge::Entity & entity = world_.Entities(id);
 		Velocity & velocity = world_.Velocities(id);
 		Position & position = world_.Positions(id);
-		if ((entity & component::player) == component::player) {
+		if ((entity & engine.Cm()["Player"]) == engine.Cm()["Player"]) {
 			position.x += velocity.x;
 			position.y += velocity.y;
 			velocity.x /= 1.1f;
@@ -76,11 +76,11 @@ void PlayState::Update(ge::GameEngine const & game) {
 }
 
 void PlayState::Display(ge::GameEngine & engine, const float) {
-	for (uint32_t id = 0; id < settings::ENTITY_COUNT; ++id) {
-		Entity & entity = world_.Entities(id);
+	for (uint32_t id = 0; id < ge::Settings::EntitiesCount; ++id) {
+		ge::Entity & entity = world_.Entities(id);
 		Sprite & sprite = world_.Sprites(id);
 		Position & position = world_.Positions(id);
-		if ((entity & component::drawable) == component::drawable) {
+		if ((entity & engine.Cm()["Drawable"]) == engine.Cm()["Drawable"]) {
 			sf::Sprite s(engine.Rm().Texture(sprite.textureName));
 			s.setPosition(position.x, position.y);
 			engine.Draw(std::make_shared<sf::Sprite>(s), sprite.priority);

--- a/src/PlayState.h
+++ b/src/PlayState.h
@@ -28,7 +28,7 @@ public:
 	void Display(ge::GameEngine & engine, float interpolation) override;
 
 private:
-	void HandlePlayerMovement_(sf::Event::KeyEvent const & event);
+	void HandlePlayerMovement_(ge::GameEngine const & engine, sf::Event::KeyEvent const & event);
 	void HandleQuit_(ge::GameEngine & engine, sf::Event::KeyEvent const & event);
 
 	PlayWorld world_;

--- a/src/PlayWorld.cc
+++ b/src/PlayWorld.cc
@@ -1,17 +1,17 @@
 #include "PlayWorld.h"
 
-uint32_t PlayWorld::CreatePlayer(Position const & position, Velocity const & velocities, Sprite const & sprite) {
+uint32_t PlayWorld::CreatePlayer(ge::Component const & component, Position const & position, Velocity const & velocities, Sprite const & sprite) {
 	uint32_t id = GetEmptyIndex_();
-	entities_[id] = component::player;
+	entities_[id] = component;
 	positions_[id] = position;
 	velocities_[id] = velocities;
 	sprites_[id] = sprite;
 	return id;
 }
 
-uint32_t PlayWorld::CreateCross(Position const &position, Sprite const & sprite) {
+uint32_t PlayWorld::CreateCross(ge::Component const & component, Position const &position, Sprite const & sprite) {
 	uint32_t id = GetEmptyIndex_();
-	entities_[id] = component::drawable;
+	entities_[id] = component;
 	positions_[id] = position;
 	sprites_[id] = sprite;
 	return id;

--- a/src/PlayWorld.h
+++ b/src/PlayWorld.h
@@ -2,6 +2,7 @@
 #define PLAYWORLD_H_
 
 #include "AWorld.h"
+#include "Components.h"
 
 class PlayWorld : public ge::AWorld {
 public:
@@ -13,17 +14,17 @@ public:
 	PlayWorld & operator=(PlayWorld const & other) = delete;
 	PlayWorld & operator=(PlayWorld && other) = delete;
 
-	uint32_t CreatePlayer(Position const & position, Velocity const & velocities, Sprite const & sprite);
-	uint32_t CreateCross(Position const & position, Sprite const & sprite);
+	uint32_t CreatePlayer(ge::Component const & component, Position const & position, Velocity const & velocities, Sprite const & sprite);
+	uint32_t CreateCross(ge::Component const & component, Position const & position, Sprite const & sprite);
 
 	Sprite & Sprites(uint32_t id);
 	Position & Positions(uint32_t id);
 	Velocity & Velocities(uint32_t id);
 
 private:
-	std::array<Sprite, settings::ENTITY_COUNT> sprites_{};
-	std::array<Position, settings::ENTITY_COUNT> positions_{};
-	std::array<Velocity, settings::ENTITY_COUNT> velocities_{};
+	std::array<Sprite, ge::Settings::EntitiesCount> sprites_{};
+	std::array<Position, ge::Settings::EntitiesCount> positions_{};
+	std::array<Velocity, ge::Settings::EntitiesCount> velocities_{};
 };
 
 #endif /* PLAYWORLD_H_ */

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "GameEngine.h"
 #include "IntroState.h"
 #include "PlayState.h"
@@ -5,6 +7,15 @@
 int main() {
 	ge::GameEngine gameEngine;
 	if (gameEngine.Init("R-Type", 800, 600)) {
+		gameEngine.Cm().AddComponents("Position");
+		gameEngine.Cm().AddComponents("Velocity");
+		gameEngine.Cm().AddComponents("Sprite");
+		gameEngine.Cm().AddComponents("Text");
+		gameEngine.Cm().AddComponents("Input");
+		gameEngine.Cm().AddComponents("PlayerTag");
+		gameEngine.Cm().AddComposedComponents("Button", {"Position", "Text", "Input"} );
+		gameEngine.Cm().AddComposedComponents("Drawable", {"Position", "Sprite"} );
+		gameEngine.Cm().AddComposedComponents("Player", {"Position", "Velocity", "Sprite", "PlayerTag"} );
 		gameEngine.AddState("Intro", std::make_shared<IntroState>());
 		gameEngine.AddState("Play", std::make_shared<PlayState>());
 		gameEngine.Run("Intro");

--- a/src/main.cc
+++ b/src/main.cc
@@ -7,12 +7,7 @@
 int main() {
 	ge::GameEngine gameEngine;
 	if (gameEngine.Init("R-Type", 800, 600)) {
-		gameEngine.Cm().AddComponents("Position");
-		gameEngine.Cm().AddComponents("Velocity");
-		gameEngine.Cm().AddComponents("Sprite");
-		gameEngine.Cm().AddComponents("Text");
-		gameEngine.Cm().AddComponents("Input");
-		gameEngine.Cm().AddComponents("PlayerTag");
+		gameEngine.Cm().AddComponents( {"Position", "Velocity", "Sprite", "Text", "Input", "PlayerTag"} );
 		gameEngine.Cm().AddComposedComponents("Button", {"Position", "Text", "Input"} );
 		gameEngine.Cm().AddComposedComponents("Drawable", {"Position", "Sprite"} );
 		gameEngine.Cm().AddComposedComponents("Player", {"Position", "Velocity", "Sprite", "PlayerTag"} );


### PR DESCRIPTION
Add a component manager that hide component's bitset setting from the user, and enable the GameEngine to declare preset it's own special components and to be stand alone.
Some refactoring will come next to prevent user to access to managers in the gameEngine and only use the GameEngine class.